### PR TITLE
Incorporate Polyscripting Defense against Code Injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository shows how to run Wordpress on Docker while keeping the PHP code,
 *Note: This repository is meant to be an example and should not be used in production without testing your application against this configuration.*
 
 ## Limitations
-- Wordpress Core, Plugins, and Themes must be updated via the Docker build process and not in the Wordpress Admin. Doing so will result in containers having different versions of plugins.
-- This assumes all dynamic content is stored int he `wp-content/uploads` folder
+- Wordpress Core, Plugins, and Themes work across containers by persisting them in the `/wordpress` folder.
+- This assumes all dynamic content is stored in the `/uploads` folder
 
 ## Getting Started
 
@@ -20,9 +20,50 @@ make build
 make WORDPRESS_VERSION=5.2.5 WORDPRESS_SHA1=1afb2e9a10be336773a62a120bb4cfb44214dfcc build
 ```
 
+
+## Polyscripted PHP for defense against Code-Injections
+
+This container also optionally provides [Polyverse's open source Polyscripting](https://polyverse.com/polyscripting/) 
+defense for PHP. This is merely enabled by adding an environment variable "MODE=polyscripted" to the wordpress container.
+
+The details on Polyscripting can be found at this link: [https://polyverse.com/polyscripting](https://polyverse.com/polyscripting/)
+
+Quick Summary: 
+* Polyscripting stops runtime-injected code from being executed. 
+* PHP and particularly Wordpress websites are susceptible to code-injection attacks frequently.
+* Polyscripting does this by generating a new PHP-derived language on-the-fly just before the container serves requests, and then transforming the entire wordpress code to this new language.
+* This is different from obfuscation because the language itself is changing.
+
+#### Limitations
+In Polyscripted mode, the wordpress instance cannot be updated and new plugins cannot be installed because the code is
+closed for modification. It is recommended to start a container in non-polyscripted mode, perform maintenance, and restart in polyscripted mode for safety.
+
+In real-life production use, it is possible to start an internal-only unpolyscripted instance with the shared volume, performing maintenance and then restarting the external-facing polyscripted instances to pick up the changes.
+
+#### Testing Polyscripting defense
+
+You can view an online-demo here: https://polyverse.com/learn/polyscripted-wordpress/
+
+You can also place this trivially-remotely-injectable page in your wordpress folder:
+
+```php
+<?php
+$myvar = "varname";
+$x = $_GET['arg'];
+eval("\$myvar = \$x;");
+?>
+```
+
+And you can call (adjusted for your endpoint): https://localhost:8080/hack.php?arg=1%3B%20echo%20phpinfo%28%29%3B
+
+You'll find phpinfo() is echo'd on a non-polyscripted endpoint, but generates a syntax error on a polyscripted endpoint.
+
 ## Deployment
 
-This container is designed to be deployed to multiple orchestration systems such as Amazon ECS or Kubernetes. The container has one requirement for storage to mounted at `/var/www/html/wp-content/uploads`. This is so that when users upload images they will be persisted and can be shared across containers. I recommend using a NFS based volume such as Amazon EFS.
+This container is designed to be deployed to multiple orchestration systems such as Amazon ECS or Kubernetes. The container has two requirements for storage to be mounted for persistence. This is so that when users upload images they will be persisted and can be shared across containers. I recommend using a NFS based volume such as Amazon EFS.
+
+*  `/wordpress` - for storing wordpress files (plugins, updates, etc.) are persisted across containers
+*  `/uploads` - for storing uploaded images and persisted across containers
 
 ### Kubernetes on Amazon EKS
 
@@ -75,6 +116,8 @@ This file is an exmaple that you can run locally and shows how to deploy Wordpre
 
 ```bash
 
+# OPTIONAL: Start wordpress with Polyscripting enabled
+MODE=polyscripted
 # start wordpress, the site will be available at http://localhost:8080
 docker-compose -f ./examples/docker-compose.yml -p wordpress up
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# DEPRECATION NOTICE
+
+Please note that this repository has been deprecated and is no longer actively maintained by Polyverse Corporation.  It may be removed in the future, but for now remains public for the benefit of any users.
+
+Importantly, as the repository has not been maintained, it may contain unpatched security issues and other critical issues.  Use at your own risk.
+
+While it is not maintained, we would graciously consider any pull requests in accordance with our Individual Contributor License Agreement.  https://github.com/polyverse/contributor-license-agreement
+
+For any other issues, please feel free to contact info@polyverse.com
+
+---
+
 # Wordpress on Docker
 
 This repository shows how to run Wordpress on Docker while keeping the PHP code, plugins, and themes within source control. This has advantages to running Wordpress out of a shared file system. This enables Wordpress, Custom Code, and the PHP configuration to be tested a single unit prior deploying to production. This does have limitations which is documented below.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM polyverse/ps-php7.4-apache:15deefdb40a1a73943eec9d2c6442cf4cdf67cf6
+# FROM php:7.4-apache
+
+# Start with a polyscripting-capable php7.4-apache container
+# Source: https://github.com/polyverse/php/blob/master/7.4/buster/apache/Dockerfile
+FROM polyverse/ps-php7.4-apache:8da9a6be4ddc1e4d718b0e4238da3cd1f348f283
 
 # persistent dependencies
 RUN set -eux; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM polyverse/ps-php7.4-apache:97908964ff927880dcb526f5e355bcac71fa45de
+FROM polyverse/ps-php7.4-apache:15deefdb40a1a73943eec9d2c6442cf4cdf67cf6
 
 # persistent dependencies
 RUN set -eux; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM polyverse/ps-php7.4-apache:29a4ecd4cb9588beca88dd8f381bdc39455d6b0a
 
 # persistent dependencies
 RUN set -eux; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,6 @@ RUN set -ex; \
 		| sort -u \
 		| xargs -rt apt-mark manual; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM polyverse/ps-php7.4-apache:29a4ecd4cb9588beca88dd8f381bdc39455d6b0a
+FROM polyverse/ps-php7.4-apache:6c4adc6c1eb9d4570b3d424afef257b923850a4d
 
 # persistent dependencies
 RUN set -eux; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,26 +95,25 @@ RUN set -eux; \
 ARG WORDPRESS_VERSION=5.3.2
 ARG WORDPRESS_SHA1=fded476f112dbab14e3b5acddd2bcfa550e7b01b
 
+# Initialize wordpress at /wordpress for staging
+# The scrambler script will either copy it as-is
+# to the /var/www/html directory, or copy it post-scrambling
+# so that it is transformed to run with the Polyscripted PHP
 RUN set -ex; \
 	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \
 	echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
-# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
-	tar -xzf wordpress.tar.gz -C /usr/src/; \
-    cp -r /usr/src/wordpress/* /var/www/html/; \
-	rm wordpress.tar.gz; \
-    rm -rf /usr/src; \
-	chown -R www-data:www-data /var/www/html; \
-	rm -rf /var/www/html/wp-content/plugins; \
-	rm -rf /var/www/html/wp-content/themes;
+# upstream tarballs include ./wordpress/ so this gives us /wordpress
+	tar -xzf wordpress.tar.gz -C /; \
+	rm -rf /wordpress/wp-content/plugins; \
+	rm -rf /wordpress/wp-content/themes;
+
+COPY ./wp-content/plugins /wordpress/wp-content/plugins
+COPY ./wp-content/themes /wordpress/wp-content/themes
+
+VOLUME /uploads
 
 COPY docker-entrypoint.sh /usr/local/bin/
-
-COPY ./wp-content/plugins /var/www/html/wp-content/plugins
-COPY ./wp-content/themes /var/www/html/wp-content/themes
-
-RUN chown -R www-data:www-data /var/www/html/wp-content
-
-VOLUME /var/www/html/wp-content/uploads
+COPY scramble.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM polyverse/ps-php7.4-apache:6c4adc6c1eb9d4570b3d424afef257b923850a4d
+FROM polyverse/ps-php7.4-apache:97908964ff927880dcb526f5e355bcac71fa45de
 
 # persistent dependencies
 RUN set -eux; \
@@ -95,6 +95,9 @@ RUN set -eux; \
 ARG WORDPRESS_VERSION=5.3.2
 ARG WORDPRESS_SHA1=fded476f112dbab14e3b5acddd2bcfa550e7b01b
 
+VOLUME /uploads
+VOLUME /wordpress
+
 # Initialize wordpress at /wordpress for staging
 # The scrambler script will either copy it as-is
 # to the /var/www/html directory, or copy it post-scrambling
@@ -110,7 +113,6 @@ RUN set -ex; \
 COPY ./wp-content/plugins /wordpress/wp-content/plugins
 COPY ./wp-content/themes /wordpress/wp-content/themes
 
-VOLUME /uploads
 
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY scramble.sh /usr/local/bin/

--- a/docker/scramble.sh
+++ b/docker/scramble.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+rm -rf /var/www/html
+
+if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
+
+	echo "===================== POLYSCRIPTING ENABLED =========================="
+	if [ -d /wordpress ]; then
+	    echo "Copying /wordpress to /var/www/html to be polyscripted in place..."
+	    echo "This will prevent changes from being saved back to /wordpress, but will protect"
+	    echo "against code injection attacks..."
+		cp -R /wordpress /var/www/html
+	fi
+
+	echo "Starting polyscripted WordPress"
+	cd $POLYSCRIPT_PATH
+	sed -i "/#mod_allow/a \define( 'DISALLOW_FILE_MODS', true );" /var/www/html/wp-config.php
+    	./build-scrambled.sh
+	if [ -f scrambled.json ] && s_php tok-php-transformer.php -p /var/www/html --replace; then
+		echo "Polyscripting enabled."
+		echo "done"
+	else
+		echo "Polyscripting failed."
+		cp /usr/local/bin/s_php /usr/local/bin/php
+		exit 1
+	fi
+	if [ -d /uploads ]; then
+		ln -s /uploads /var/www/html/wp-content/uploads
+	else 	
+		rm  -rf /var/www/html/wp-content/uploads
+		ln -s /wordpress/wp-content/uploads /var/www/html/wp-content/uploads
+	fi
+else
+    echo "Polyscripted mode is off. To enable it, either:"
+    echo "  1. Set the environment variable: MODE=polyscripted"
+    echo "  2. OR create a file at path: /polyscripted"
+
+    # Symlink the mount so it's editable
+    ln -s /wordpress /var/www/html
+fi
+

--- a/docker/scramble.sh
+++ b/docker/scramble.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-rm -rf /var/www/html
-ls -trla /var/www/html
-echo "Contents of /var/www"
-ls -trla /var/www
+if [[ -d /var/www/html ]]; then
+	echo "Remvoing /var/www/html to mount it from /wordpress where files are stored"
+	rm -rf /var/www/html
+fi
 
 if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
 
@@ -27,13 +27,6 @@ if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
 		cp /usr/local/bin/s_php /usr/local/bin/php
 		exit 1
 	fi
-
-        rm  -rf /var/www/html/wp-content/uploads
-	if [[ -d /uploads ]]; then
-		ln -s /uploads /var/www/html/wp-content/uploads
-	else
-		ln -s /wordpress/wp-content/uploads /var/www/html/wp-content/uploads
-	fi
 else
     echo "Polyscripted mode is off. To enable it, either:"
     echo "  1. Set the environment variable: MODE=polyscripted"
@@ -43,3 +36,8 @@ else
     ln -s /wordpress /var/www/html
 fi
 
+rm  -rf /var/www/html/wp-content/uploads
+if [[ ! -d /uploads ]]; then
+	mkdir /uploads
+fi
+ln -s /uploads /var/www/html/wp-content/uploads

--- a/docker/scramble.sh
+++ b/docker/scramble.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 rm -rf /var/www/html
+ls -trla /var/www/html
+echo "Contents of /var/www"
+ls -trla /var/www
 
 if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
 
@@ -24,10 +27,11 @@ if [[ "$MODE" == "polyscripted" || -f /polyscripted ]]; then
 		cp /usr/local/bin/s_php /usr/local/bin/php
 		exit 1
 	fi
-	if [ -d /uploads ]; then
+
+        rm  -rf /var/www/html/wp-content/uploads
+	if [[ -d /uploads ]]; then
 		ln -s /uploads /var/www/html/wp-content/uploads
-	else 	
-		rm  -rf /var/www/html/wp-content/uploads
+	else
 		ln -s /wordpress/wp-content/uploads /var/www/html/wp-content/uploads
 	fi
 else

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -18,8 +18,10 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: supersecretpassword
+      MODE: ${MODE}
     volumes:
-      - wordpress-uploads:/var/www/html/wp-content/uploads
+      - wordpress-uploads:/uploads
+      - wordpress:/wordpress
 
   database:
     image: mariadb
@@ -35,3 +37,4 @@ services:
 volumes:
   db-data: {}
   wordpress-uploads: {}
+  wordpress: {}


### PR DESCRIPTION
This change incorporates Polyverse's [Polyscripting](https://polyverse.com/polyscripting) technology for PHP into the reference architecture.

# The Problem

One of the common challenges with Wordpress, without argument, is that of constant code-injection attacks. Whether it is in core PHP, Wordpress, Shared libraries or plugins. The challenge is pervasive and frequent.

# The Solution

Basically while solutions for code-signing, validation, static analysis, reviews, testing, fuzzing, etc. exist, the fact that code-injections continue to happen frequently means that a new approach is needed.

[Polyscripting](https://polyverse.com/polyscripting) is a technology by Polyverse to fundamentally scramble the very Programming Language of PHP itself on every start-time, and transform all closure of wordpress code (including plugins) that conforms to this New Language.

A lot more details can be found in the Readme, along with how to update/install plugins, a sample synthetic injection vulnerability that can be used to test the specific problem Polyscripting solves.

# Impact

By default, nothing whatsoever changes. It is all plain PHP. Unless Polyscripting mode is engaged, fundamentally everything remains the same. This should be a low-impact change. All upstream code is published on Github and linked.